### PR TITLE
Duplicate names should not be allowed in some entities.

### DIFF
--- a/service/core/action/category/create.go
+++ b/service/core/action/category/create.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/factly/x/loggerx"
 
@@ -79,13 +78,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if category with same name exist
-	newCategoryName := strings.ToLower(strings.TrimSpace(category.Name))
-	var categoryCount int
-	config.DB.Model(&model.Category{}).Where(&model.Category{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newCategoryName).Count(&categoryCount)
-
-	if categoryCount > 0 {
+	if util.CheckName(uint(sID), category.Name, config.DB.NewScope(&model.Category{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/service/core/action/category/update.go
+++ b/service/core/action/category/update.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
@@ -95,6 +96,19 @@ func update(w http.ResponseWriter, r *http.Request) {
 		categorySlug = slug.Approve(category.Slug, sID, config.DB.NewScope(&model.Category{}).TableName())
 	} else {
 		categorySlug = slug.Approve(slug.Make(category.Name), sID, config.DB.NewScope(&model.Category{}).TableName())
+	}
+
+	// Check if category with same name exist
+	newCategoryName := strings.ToLower(strings.TrimSpace(category.Name))
+	var sameCat model.Category
+	err = config.DB.Model(&model.Category{}).Where(&model.Category{
+		SpaceID: uint(sID),
+	}).Where("name ILIKE ?", newCategoryName).Find(&sameCat).Error
+
+	if err == nil && sameCat.ID != uint(id) {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
+		return
 	}
 
 	tx := config.DB.Begin()

--- a/service/core/action/category/update.go
+++ b/service/core/action/category/update.go
@@ -103,7 +103,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	var sameCat model.Category
 	err = config.DB.Model(&model.Category{}).Where(&model.Category{
 		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newCategoryName).Find(&sameCat).Error
+	}).Where("name ILIKE ?", newCategoryName).First(&sameCat).Error
 
 	if err == nil && sameCat.ID != uint(id) {
 		loggerx.Error(err)

--- a/service/core/action/category/update.go
+++ b/service/core/action/category/update.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
@@ -99,13 +98,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if category with same name exist
-	newCategoryName := strings.ToLower(strings.TrimSpace(category.Name))
-	var sameCat model.Category
-	err = config.DB.Model(&model.Category{}).Where(&model.Category{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newCategoryName).First(&sameCat).Error
-
-	if err == nil && sameCat.ID != uint(id) {
+	if category.Name != result.Name && util.CheckName(uint(sID), category.Name, config.DB.NewScope(&model.Category{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/service/core/action/format/create.go
+++ b/service/core/action/format/create.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
@@ -65,13 +64,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if format with same name exist
-	newFormatName := strings.ToLower(strings.TrimSpace(format.Name))
-	var formatCount int
-	config.DB.Model(&model.Format{}).Where(&model.Format{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newFormatName).Count(&formatCount)
-
-	if formatCount > 0 {
+	if util.CheckName(uint(sID), format.Name, config.DB.NewScope(&model.Format{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/service/core/action/format/update.go
+++ b/service/core/action/format/update.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
@@ -92,13 +91,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if format with same name exist
-	newFormatName := strings.ToLower(strings.TrimSpace(format.Name))
-	var sameFormat model.Format
-	err = config.DB.Model(&model.Format{}).Where(&model.Format{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newFormatName).First(&sameFormat).Error
-
-	if err == nil && sameFormat.ID != uint(id) {
+	if format.Name != result.Name && util.CheckName(uint(sID), format.Name, config.DB.NewScope(&model.Format{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/service/core/action/format/update.go
+++ b/service/core/action/format/update.go
@@ -96,7 +96,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	var sameFormat model.Format
 	err = config.DB.Model(&model.Format{}).Where(&model.Format{
 		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newFormatName).Find(&sameFormat).Error
+	}).Where("name ILIKE ?", newFormatName).First(&sameFormat).Error
 
 	if err == nil && sameFormat.ID != uint(id) {
 		loggerx.Error(err)

--- a/service/core/action/tag/create.go
+++ b/service/core/action/tag/create.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
@@ -66,13 +65,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if tag with same name exist
-	newTagName := strings.ToLower(strings.TrimSpace(tag.Name))
-	var tagCount int
-	config.DB.Model(&model.Tag{}).Where(&model.Tag{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newTagName).Count(&tagCount)
-
-	if tagCount > 0 {
+	if util.CheckName(uint(sID), tag.Name, config.DB.NewScope(&model.Tag{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/service/core/action/tag/update.go
+++ b/service/core/action/tag/update.go
@@ -95,7 +95,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	var sameTag model.Tag
 	err = config.DB.Model(&model.Tag{}).Where(&model.Tag{
 		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newTagName).Find(&sameTag).Error
+	}).Where("name ILIKE ?", newTagName).First(&sameTag).Error
 
 	if err == nil && sameTag.ID != uint(id) {
 		loggerx.Error(err)

--- a/service/core/action/tag/update.go
+++ b/service/core/action/tag/update.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
@@ -91,13 +90,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if tag with same name exist
-	newTagName := strings.ToLower(strings.TrimSpace(tag.Name))
-	var sameTag model.Tag
-	err = config.DB.Model(&model.Tag{}).Where(&model.Tag{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newTagName).First(&sameTag).Error
-
-	if err == nil && sameTag.ID != uint(id) {
+	if tag.Name != result.Name && util.CheckName(uint(sID), tag.Name, config.DB.NewScope(&model.Tag{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/service/fact-check/action/rating/create.go
+++ b/service/fact-check/action/rating/create.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/fact-check/model"
@@ -65,13 +64,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if rating with same name exist
-	newRatingName := strings.ToLower(strings.TrimSpace(rating.Name))
-	var ratingCount int
-	config.DB.Model(&model.Rating{}).Where(&model.Rating{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newRatingName).Count(&ratingCount)
-
-	if ratingCount > 0 {
+	if util.CheckName(uint(sID), rating.Name, config.DB.NewScope(&model.Rating{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/service/fact-check/action/rating/update.go
+++ b/service/fact-check/action/rating/update.go
@@ -95,7 +95,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	var sameRating model.Rating
 	err = config.DB.Model(&model.Rating{}).Where(&model.Rating{
 		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newRatingName).Find(&sameRating).Error
+	}).Where("name ILIKE ?", newRatingName).First(&sameRating).Error
 
 	if err == nil && sameRating.ID != uint(id) {
 		loggerx.Error(err)

--- a/service/fact-check/action/rating/update.go
+++ b/service/fact-check/action/rating/update.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/fact-check/model"
@@ -91,13 +90,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if rating with same name exist
-	newRatingName := strings.ToLower(strings.TrimSpace(rating.Name))
-	var sameRating model.Rating
-	err = config.DB.Model(&model.Rating{}).Where(&model.Rating{
-		SpaceID: uint(sID),
-	}).Where("name ILIKE ?", newRatingName).First(&sameRating).Error
-
-	if err == nil && sameRating.ID != uint(id) {
+	if rating.Name != result.Name && util.CheckName(uint(sID), rating.Name, config.DB.NewScope(&model.Rating{}).TableName()) {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.CannotSaveChanges()))
 		return

--- a/test/service/core/category/create_test.go
+++ b/test/service/core/category/create_test.go
@@ -53,7 +53,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("create category without parent", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		insertMock(mock)
@@ -90,7 +90,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("create category with empty slug", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		insertMock(mock)
@@ -113,7 +113,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("medium does not belong same space", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		insertWithMediumError(mock)
@@ -130,7 +130,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("medium does not exist", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		insertWithMediumError(mock)
@@ -147,7 +147,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("when category with same name exist", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 1)
+		sameNameCount(mock, 1, Data["name"])
 
 		e.POST(basePath).
 			WithHeaders(headers).
@@ -161,7 +161,7 @@ func TestCategoryCreate(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		insertMock(mock)

--- a/test/service/core/category/create_test.go
+++ b/test/service/core/category/create_test.go
@@ -53,6 +53,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("create category without parent", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		insertMock(mock)
@@ -89,6 +90,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("create category with empty slug", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		insertMock(mock)
@@ -111,6 +113,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("medium does not belong same space", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		insertWithMediumError(mock)
@@ -127,6 +130,7 @@ func TestCategoryCreate(t *testing.T) {
 	t.Run("medium does not exist", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		insertWithMediumError(mock)
@@ -140,10 +144,24 @@ func TestCategoryCreate(t *testing.T) {
 		test.ExpectationsMet(t, mock)
 	})
 
+	t.Run("when category with same name exist", func(t *testing.T) {
+		test.CheckSpaceMock(mock)
+
+		sameNameCount(mock, 1)
+
+		e.POST(basePath).
+			WithHeaders(headers).
+			WithJSON(Data).
+			Expect().
+			Status(http.StatusUnprocessableEntity)
+		test.ExpectationsMet(t, mock)
+	})
+
 	t.Run("create category when meili is down", func(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		insertMock(mock)

--- a/test/service/core/category/testvars.go
+++ b/test/service/core/category/testvars.go
@@ -75,21 +75,10 @@ func slugCheckMock(mock sqlmock.Sqlmock, category map[string]interface{}) {
 		WillReturnRows(sqlmock.NewRows(Columns))
 }
 
-func sameNameCount(mock sqlmock.Sqlmock, count int) {
+func sameNameCount(mock sqlmock.Sqlmock, count int, name interface{}) {
 	mock.ExpectQuery(countQuery).
-		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WithArgs(1, strings.ToLower(name.(string))).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
-}
-
-func sameNameFind(mock sqlmock.Sqlmock, found bool) {
-	mx := mock.ExpectQuery(selectQuery).
-		WithArgs(1, strings.ToLower(Data["name"].(string)))
-	if found {
-		mx.WillReturnRows(sqlmock.NewRows(Columns).
-			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"], Data["description"], Data["parent_id"], Data["medium_id"], 1))
-	} else {
-		mx.WillReturnRows(sqlmock.NewRows(Columns))
-	}
 }
 
 func insertMock(mock sqlmock.Sqlmock) {

--- a/test/service/core/category/testvars.go
+++ b/test/service/core/category/testvars.go
@@ -3,6 +3,7 @@ package category
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -72,6 +73,23 @@ func slugCheckMock(mock sqlmock.Sqlmock, category map[string]interface{}) {
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT slug, space_id FROM "categories"`)).
 		WithArgs(fmt.Sprint(category["slug"], "%"), 1).
 		WillReturnRows(sqlmock.NewRows(Columns))
+}
+
+func sameNameCount(mock sqlmock.Sqlmock, count int) {
+	mock.ExpectQuery(countQuery).
+		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+}
+
+func sameNameFind(mock sqlmock.Sqlmock, found bool) {
+	mx := mock.ExpectQuery(selectQuery).
+		WithArgs(1, strings.ToLower(Data["name"].(string)))
+	if found {
+		mx.WillReturnRows(sqlmock.NewRows(Columns).
+			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"], Data["description"], Data["parent_id"], Data["medium_id"], 1))
+	} else {
+		mx.WillReturnRows(sqlmock.NewRows(Columns))
+	}
 }
 
 func insertMock(mock sqlmock.Sqlmock) {

--- a/test/service/core/category/update_test.go
+++ b/test/service/core/category/update_test.go
@@ -80,8 +80,6 @@ func TestCategoryUpdate(t *testing.T) {
 
 		selectWithSpace(mock)
 
-		sameNameFind(mock, false)
-
 		updateMock(mock)
 		mock.ExpectCommit()
 
@@ -100,7 +98,6 @@ func TestCategoryUpdate(t *testing.T) {
 		selectWithSpace(mock)
 
 		slugCheckMock(mock, Data)
-		sameNameFind(mock, false)
 
 		updateMock(mock)
 		mock.ExpectCommit()
@@ -138,7 +135,6 @@ func TestCategoryUpdate(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
 		selectWithSpace(mock)
-		sameNameFind(mock, false)
 
 		Data["medium_id"] = 0
 		mock.ExpectBegin()
@@ -168,7 +164,6 @@ func TestCategoryUpdate(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
 		selectWithSpace(mock)
-		sameNameFind(mock, false)
 
 		mock.ExpectBegin()
 		medium.SelectWithSpace(mock)
@@ -191,7 +186,8 @@ func TestCategoryUpdate(t *testing.T) {
 
 		selectWithSpace(mock)
 
-		sameNameFind(mock, true)
+		Data["name"] = "New Category"
+		sameNameCount(mock, 1, Data["name"])
 
 		e.PUT(path).
 			WithPath("category_id", 1).
@@ -200,6 +196,7 @@ func TestCategoryUpdate(t *testing.T) {
 			Expect().
 			Status(http.StatusUnprocessableEntity)
 		test.ExpectationsMet(t, mock)
+		Data["name"] = "Test Category"
 	})
 
 	t.Run("update category when meili is down", func(t *testing.T) {
@@ -207,7 +204,6 @@ func TestCategoryUpdate(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
 		selectWithSpace(mock)
-		sameNameFind(mock, false)
 
 		updateMock(mock)
 		mock.ExpectRollback()

--- a/test/service/core/category/update_test.go
+++ b/test/service/core/category/update_test.go
@@ -80,6 +80,8 @@ func TestCategoryUpdate(t *testing.T) {
 
 		selectWithSpace(mock)
 
+		sameNameFind(mock, false)
+
 		updateMock(mock)
 		mock.ExpectCommit()
 
@@ -98,6 +100,7 @@ func TestCategoryUpdate(t *testing.T) {
 		selectWithSpace(mock)
 
 		slugCheckMock(mock, Data)
+		sameNameFind(mock, false)
 
 		updateMock(mock)
 		mock.ExpectCommit()
@@ -135,6 +138,7 @@ func TestCategoryUpdate(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
 		selectWithSpace(mock)
+		sameNameFind(mock, false)
 
 		Data["medium_id"] = 0
 		mock.ExpectBegin()
@@ -164,6 +168,7 @@ func TestCategoryUpdate(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
 		selectWithSpace(mock)
+		sameNameFind(mock, false)
 
 		mock.ExpectBegin()
 		medium.SelectWithSpace(mock)
@@ -181,11 +186,28 @@ func TestCategoryUpdate(t *testing.T) {
 		test.ExpectationsMet(t, mock)
 	})
 
+	t.Run("category with same name exist", func(t *testing.T) {
+		test.CheckSpaceMock(mock)
+
+		selectWithSpace(mock)
+
+		sameNameFind(mock, true)
+
+		e.PUT(path).
+			WithPath("category_id", 1).
+			WithHeaders(headers).
+			WithJSON(Data).
+			Expect().
+			Status(http.StatusUnprocessableEntity)
+		test.ExpectationsMet(t, mock)
+	})
+
 	t.Run("update category when meili is down", func(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 
 		selectWithSpace(mock)
+		sameNameFind(mock, false)
 
 		updateMock(mock)
 		mock.ExpectRollback()

--- a/test/service/core/format/create_test.go
+++ b/test/service/core/format/create_test.go
@@ -54,6 +54,7 @@ func TestFormatCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock)
 
 		formatInsertMock(mock)
@@ -72,6 +73,7 @@ func TestFormatCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock)
 
 		formatInsertMock(mock)
@@ -93,6 +95,7 @@ func TestFormatCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock)
 
 		mock.ExpectBegin()
@@ -109,10 +112,24 @@ func TestFormatCreate(t *testing.T) {
 		test.ExpectationsMet(t, mock)
 	})
 
+	t.Run("format with same name exist", func(t *testing.T) {
+		test.CheckSpaceMock(mock)
+
+		sameNameCount(mock, 1)
+
+		e.POST(basePath).
+			WithHeaders(headers).
+			WithJSON(Data).
+			Expect().
+			Status(http.StatusUnprocessableEntity)
+		test.ExpectationsMet(t, mock)
+	})
+
 	t.Run("create format when meili is down", func(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock)
 
 		formatInsertMock(mock)

--- a/test/service/core/format/create_test.go
+++ b/test/service/core/format/create_test.go
@@ -54,7 +54,7 @@ func TestFormatCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock)
 
 		formatInsertMock(mock)
@@ -73,7 +73,7 @@ func TestFormatCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock)
 
 		formatInsertMock(mock)
@@ -95,7 +95,7 @@ func TestFormatCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock)
 
 		mock.ExpectBegin()
@@ -115,7 +115,7 @@ func TestFormatCreate(t *testing.T) {
 	t.Run("format with same name exist", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 1)
+		sameNameCount(mock, 1, Data["name"])
 
 		e.POST(basePath).
 			WithHeaders(headers).
@@ -129,7 +129,7 @@ func TestFormatCreate(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock)
 
 		formatInsertMock(mock)

--- a/test/service/core/format/testvars.go
+++ b/test/service/core/format/testvars.go
@@ -3,6 +3,7 @@ package format
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -45,6 +46,23 @@ func formatInsertMock(mock sqlmock.Sqlmock) {
 		WillReturnRows(sqlmock.
 			NewRows([]string{"id"}).
 			AddRow(1))
+}
+
+func sameNameCount(mock sqlmock.Sqlmock, count int) {
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "formats"`)).
+		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+}
+
+func sameNameFind(mock sqlmock.Sqlmock, found bool) {
+	mx := mock.ExpectQuery(selectQuery).
+		WithArgs(1, strings.ToLower(Data["name"].(string)))
+	if found {
+		mx.WillReturnRows(sqlmock.NewRows(columns).
+			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"]))
+	} else {
+		mx.WillReturnRows(sqlmock.NewRows(columns))
+	}
 }
 
 //check format exits or not

--- a/test/service/core/format/testvars.go
+++ b/test/service/core/format/testvars.go
@@ -48,21 +48,10 @@ func formatInsertMock(mock sqlmock.Sqlmock) {
 			AddRow(1))
 }
 
-func sameNameCount(mock sqlmock.Sqlmock, count int) {
+func sameNameCount(mock sqlmock.Sqlmock, count int, name interface{}) {
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "formats"`)).
-		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WithArgs(1, strings.ToLower(name.(string))).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
-}
-
-func sameNameFind(mock sqlmock.Sqlmock, found bool) {
-	mx := mock.ExpectQuery(selectQuery).
-		WithArgs(1, strings.ToLower(Data["name"].(string)))
-	if found {
-		mx.WillReturnRows(sqlmock.NewRows(columns).
-			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"]))
-	} else {
-		mx.WillReturnRows(sqlmock.NewRows(columns))
-	}
 }
 
 //check format exits or not

--- a/test/service/core/format/update_test.go
+++ b/test/service/core/format/update_test.go
@@ -89,7 +89,6 @@ func TestFormatUpdate(t *testing.T) {
 		}
 
 		SelectWithSpace(mock)
-		sameNameFind(mock, false)
 
 		formatUpdateMock(mock, updatedFormat)
 
@@ -118,7 +117,6 @@ func TestFormatUpdate(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(columns).
 				AddRow(1, time.Now(), time.Now(), nil, updatedFormat["name"], "factcheck"))
 
-		sameNameFind(mock, false)
 		formatUpdateMock(mock, updatedFormat)
 
 		selectAfterUpdate(mock, updatedFormat)
@@ -148,7 +146,6 @@ func TestFormatUpdate(t *testing.T) {
 			WithArgs(fmt.Sprint(updatedFormat["slug"], "%"), 1).
 			WillReturnRows(sqlmock.NewRows([]string{"slug", "space_id"}))
 
-		sameNameFind(mock, false)
 		formatUpdateMock(mock, updatedFormat)
 
 		selectAfterUpdate(mock, updatedFormat)
@@ -166,12 +163,12 @@ func TestFormatUpdate(t *testing.T) {
 	t.Run("format with same name exist", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 		updatedFormat := map[string]interface{}{
-			"name": "Fact Check",
+			"name": "Fact Chk",
 			"slug": "fact-check",
 		}
 
 		SelectWithSpace(mock)
-		sameNameFind(mock, true)
+		sameNameCount(mock, 1, updatedFormat["name"])
 
 		e.PUT(path).
 			WithPath("format_id", 1).
@@ -195,7 +192,6 @@ func TestFormatUpdate(t *testing.T) {
 			WithArgs(fmt.Sprint(updatedFormat["slug"], "%"), 1).
 			WillReturnRows(sqlmock.NewRows([]string{"slug", "space_id"}))
 
-		sameNameFind(mock, false)
 		formatUpdateMock(mock, updatedFormat)
 
 		selectAfterUpdate(mock, updatedFormat)

--- a/test/service/core/format/update_test.go
+++ b/test/service/core/format/update_test.go
@@ -84,11 +84,12 @@ func TestFormatUpdate(t *testing.T) {
 	t.Run("update format", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 		updatedFormat := map[string]interface{}{
-			"name": "Article",
+			"name": "Fact Check",
 			"slug": "fact-check",
 		}
 
 		SelectWithSpace(mock)
+		sameNameFind(mock, false)
 
 		formatUpdateMock(mock, updatedFormat)
 
@@ -117,6 +118,7 @@ func TestFormatUpdate(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows(columns).
 				AddRow(1, time.Now(), time.Now(), nil, updatedFormat["name"], "factcheck"))
 
+		sameNameFind(mock, false)
 		formatUpdateMock(mock, updatedFormat)
 
 		selectAfterUpdate(mock, updatedFormat)
@@ -137,7 +139,7 @@ func TestFormatUpdate(t *testing.T) {
 	t.Run("update format with different slug", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 		updatedFormat := map[string]interface{}{
-			"name": "Article",
+			"name": "Fact Check",
 			"slug": "testing-slug",
 		}
 		SelectWithSpace(mock)
@@ -146,6 +148,7 @@ func TestFormatUpdate(t *testing.T) {
 			WithArgs(fmt.Sprint(updatedFormat["slug"], "%"), 1).
 			WillReturnRows(sqlmock.NewRows([]string{"slug", "space_id"}))
 
+		sameNameFind(mock, false)
 		formatUpdateMock(mock, updatedFormat)
 
 		selectAfterUpdate(mock, updatedFormat)
@@ -160,11 +163,29 @@ func TestFormatUpdate(t *testing.T) {
 
 	})
 
+	t.Run("format with same name exist", func(t *testing.T) {
+		test.CheckSpaceMock(mock)
+		updatedFormat := map[string]interface{}{
+			"name": "Fact Check",
+			"slug": "fact-check",
+		}
+
+		SelectWithSpace(mock)
+		sameNameFind(mock, true)
+
+		e.PUT(path).
+			WithPath("format_id", 1).
+			WithHeaders(headers).
+			WithJSON(updatedFormat).
+			Expect().
+			Status(http.StatusUnprocessableEntity)
+	})
+
 	t.Run("update format when meili is down", func(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 		updatedFormat := map[string]interface{}{
-			"name": "Article",
+			"name": "Fact Check",
 			"slug": "article",
 		}
 
@@ -174,6 +195,7 @@ func TestFormatUpdate(t *testing.T) {
 			WithArgs(fmt.Sprint(updatedFormat["slug"], "%"), 1).
 			WillReturnRows(sqlmock.NewRows([]string{"slug", "space_id"}))
 
+		sameNameFind(mock, false)
 		formatUpdateMock(mock, updatedFormat)
 
 		selectAfterUpdate(mock, updatedFormat)

--- a/test/service/core/tag/create_test.go
+++ b/test/service/core/tag/create_test.go
@@ -54,6 +54,8 @@ func TestTagCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
+
 		slugCheckMock(mock)
 
 		tagInsertMock(mock)
@@ -72,6 +74,8 @@ func TestTagCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
+
 		slugCheckMock(mock)
 
 		mock.ExpectBegin()
@@ -89,9 +93,25 @@ func TestTagCreate(t *testing.T) {
 
 	})
 
+	t.Run("tag with same name exist", func(t *testing.T) {
+
+		test.CheckSpaceMock(mock)
+
+		sameNameCount(mock, 1)
+
+		e.POST(basePath).
+			WithHeaders(headers).
+			WithJSON(Data).
+			Expect().
+			Status(http.StatusUnprocessableEntity)
+		test.ExpectationsMet(t, mock)
+	})
+
 	t.Run("create tag with slug is empty", func(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
+
+		sameNameCount(mock, 0)
 
 		slugCheckMock(mock)
 
@@ -113,6 +133,8 @@ func TestTagCreate(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 
 		test.CheckSpaceMock(mock)
+
+		sameNameCount(mock, 0)
 
 		slugCheckMock(mock)
 

--- a/test/service/core/tag/create_test.go
+++ b/test/service/core/tag/create_test.go
@@ -54,7 +54,7 @@ func TestTagCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 
 		slugCheckMock(mock)
 
@@ -74,7 +74,7 @@ func TestTagCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 
 		slugCheckMock(mock)
 
@@ -97,7 +97,7 @@ func TestTagCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 1)
+		sameNameCount(mock, 1, Data["name"])
 
 		e.POST(basePath).
 			WithHeaders(headers).
@@ -111,7 +111,7 @@ func TestTagCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 
 		slugCheckMock(mock)
 
@@ -134,7 +134,7 @@ func TestTagCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 
 		slugCheckMock(mock)
 

--- a/test/service/core/tag/testvars.go
+++ b/test/service/core/tag/testvars.go
@@ -3,6 +3,7 @@ package tag
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -52,6 +53,23 @@ func recordNotFoundMock(mock sqlmock.Sqlmock) {
 	mock.ExpectQuery(selectQuery).
 		WithArgs(100, 1).
 		WillReturnRows(sqlmock.NewRows(Columns))
+}
+
+func sameNameCount(mock sqlmock.Sqlmock, count int) {
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "tags"`)).
+		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+}
+
+func sameNameFind(mock sqlmock.Sqlmock, found bool) {
+	mx := mock.ExpectQuery(selectQuery).
+		WithArgs(1, strings.ToLower(Data["name"].(string)))
+	if found {
+		mx.WillReturnRows(sqlmock.NewRows(Columns).
+			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"], 1))
+	} else {
+		mx.WillReturnRows(sqlmock.NewRows(Columns))
+	}
 }
 
 func SelectWithSpaceMock(mock sqlmock.Sqlmock) {

--- a/test/service/core/tag/testvars.go
+++ b/test/service/core/tag/testvars.go
@@ -55,21 +55,10 @@ func recordNotFoundMock(mock sqlmock.Sqlmock) {
 		WillReturnRows(sqlmock.NewRows(Columns))
 }
 
-func sameNameCount(mock sqlmock.Sqlmock, count int) {
+func sameNameCount(mock sqlmock.Sqlmock, count int, name interface{}) {
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "tags"`)).
-		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WithArgs(1, strings.ToLower(name.(string))).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
-}
-
-func sameNameFind(mock sqlmock.Sqlmock, found bool) {
-	mx := mock.ExpectQuery(selectQuery).
-		WithArgs(1, strings.ToLower(Data["name"].(string)))
-	if found {
-		mx.WillReturnRows(sqlmock.NewRows(Columns).
-			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"], 1))
-	} else {
-		mx.WillReturnRows(sqlmock.NewRows(Columns))
-	}
 }
 
 func SelectWithSpaceMock(mock sqlmock.Sqlmock) {

--- a/test/service/core/tag/update_test.go
+++ b/test/service/core/tag/update_test.go
@@ -83,8 +83,6 @@ func TestTagUpdate(t *testing.T) {
 
 		SelectWithSpaceMock(mock)
 
-		sameNameFind(mock, false)
-
 		tagUpdateMock(mock, updatedTag)
 		mock.ExpectCommit()
 
@@ -109,8 +107,6 @@ func TestTagUpdate(t *testing.T) {
 			WithArgs("elections%", 1).
 			WillReturnRows(sqlmock.NewRows(Columns).
 				AddRow(1, time.Now(), time.Now(), nil, updatedTag["name"], "elections", 1))
-
-		sameNameFind(mock, false)
 
 		tagUpdateMock(mock, updatedTag)
 		mock.ExpectCommit()
@@ -137,7 +133,6 @@ func TestTagUpdate(t *testing.T) {
 			WithArgs(fmt.Sprint(updatedTag["slug"], "%"), 1).
 			WillReturnRows(sqlmock.NewRows([]string{"slug", "space_id"}))
 
-		sameNameFind(mock, false)
 		tagUpdateMock(mock, updatedTag)
 		mock.ExpectCommit()
 
@@ -153,13 +148,13 @@ func TestTagUpdate(t *testing.T) {
 	t.Run("tag with same name exist", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 		updatedTag := map[string]interface{}{
-			"name": "Elections",
+			"name": "NewElections",
 			"slug": "elections",
 		}
 
 		SelectWithSpaceMock(mock)
 
-		sameNameFind(mock, true)
+		sameNameCount(mock, 1, updatedTag["name"])
 
 		e.PUT(path).
 			WithPath("tag_id", 1).
@@ -179,7 +174,6 @@ func TestTagUpdate(t *testing.T) {
 
 		SelectWithSpaceMock(mock)
 
-		sameNameFind(mock, false)
 		tagUpdateMock(mock, updatedTag)
 		mock.ExpectRollback()
 

--- a/test/service/fact-check/rating/create_test.go
+++ b/test/service/fact-check/rating/create_test.go
@@ -53,7 +53,7 @@ func TestRatingCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		ratingInsertMock(mock)
@@ -73,7 +73,7 @@ func TestRatingCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		ratingInsertMock(mock)
@@ -97,7 +97,7 @@ func TestRatingCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		ratingInsertError(mock)
@@ -114,7 +114,7 @@ func TestRatingCreate(t *testing.T) {
 	t.Run("rating with same name exist", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 1)
+		sameNameCount(mock, 1, Data["name"])
 
 		e.POST(basePath).
 			WithHeaders(headers).
@@ -128,7 +128,7 @@ func TestRatingCreate(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 
-		sameNameCount(mock, 0)
+		sameNameCount(mock, 0, Data["name"])
 		slugCheckMock(mock, Data)
 
 		ratingInsertMock(mock)

--- a/test/service/fact-check/rating/create_test.go
+++ b/test/service/fact-check/rating/create_test.go
@@ -53,6 +53,7 @@ func TestRatingCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		ratingInsertMock(mock)
@@ -72,6 +73,7 @@ func TestRatingCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		ratingInsertMock(mock)
@@ -95,6 +97,7 @@ func TestRatingCreate(t *testing.T) {
 
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		ratingInsertError(mock)
@@ -108,10 +111,24 @@ func TestRatingCreate(t *testing.T) {
 		test.ExpectationsMet(t, mock)
 	})
 
+	t.Run("rating with same name exist", func(t *testing.T) {
+		test.CheckSpaceMock(mock)
+
+		sameNameCount(mock, 1)
+
+		e.POST(basePath).
+			WithHeaders(headers).
+			WithJSON(Data).
+			Expect().
+			Status(http.StatusUnprocessableEntity)
+		test.ExpectationsMet(t, mock)
+	})
+
 	t.Run("create rating when meili is down", func(t *testing.T) {
 		test.DisableMeiliGock(testServer.URL)
 		test.CheckSpaceMock(mock)
 
+		sameNameCount(mock, 0)
 		slugCheckMock(mock, Data)
 
 		ratingInsertMock(mock)

--- a/test/service/fact-check/rating/testvars.go
+++ b/test/service/fact-check/rating/testvars.go
@@ -3,6 +3,7 @@ package rating
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -95,6 +96,23 @@ func recordNotFoundMock(mock sqlmock.Sqlmock) {
 	mock.ExpectQuery(selectQuery).
 		WithArgs(100, 1).
 		WillReturnRows(sqlmock.NewRows(columns))
+}
+
+func sameNameCount(mock sqlmock.Sqlmock, count int) {
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "ratings"`)).
+		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+}
+
+func sameNameFind(mock sqlmock.Sqlmock, found bool) {
+	mx := mock.ExpectQuery(selectQuery).
+		WithArgs(1, strings.ToLower(Data["name"].(string)))
+	if found {
+		mx.WillReturnRows(sqlmock.NewRows(columns).
+			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"], Data["medium_id"], Data["description"], Data["numeric_value"], 1))
+	} else {
+		mx.WillReturnRows(sqlmock.NewRows(columns))
+	}
 }
 
 // check rating associated with any claim before deleting

--- a/test/service/fact-check/rating/testvars.go
+++ b/test/service/fact-check/rating/testvars.go
@@ -98,21 +98,10 @@ func recordNotFoundMock(mock sqlmock.Sqlmock) {
 		WillReturnRows(sqlmock.NewRows(columns))
 }
 
-func sameNameCount(mock sqlmock.Sqlmock, count int) {
+func sameNameCount(mock sqlmock.Sqlmock, count int, name interface{}) {
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "ratings"`)).
-		WithArgs(1, strings.ToLower(Data["name"].(string))).
+		WithArgs(1, strings.ToLower(name.(string))).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
-}
-
-func sameNameFind(mock sqlmock.Sqlmock, found bool) {
-	mx := mock.ExpectQuery(selectQuery).
-		WithArgs(1, strings.ToLower(Data["name"].(string)))
-	if found {
-		mx.WillReturnRows(sqlmock.NewRows(columns).
-			AddRow(2, time.Now(), time.Now(), nil, Data["name"], Data["slug"], Data["medium_id"], Data["description"], Data["numeric_value"], 1))
-	} else {
-		mx.WillReturnRows(sqlmock.NewRows(columns))
-	}
 }
 
 // check rating associated with any claim before deleting

--- a/test/service/fact-check/rating/update_test.go
+++ b/test/service/fact-check/rating/update_test.go
@@ -89,8 +89,6 @@ func TestRatingUpdate(t *testing.T) {
 
 		SelectWithSpace(mock)
 
-		sameNameFind(mock, false)
-
 		ratingUpdateMock(mock, updatedRating, nil)
 		mock.ExpectCommit()
 
@@ -109,7 +107,6 @@ func TestRatingUpdate(t *testing.T) {
 		SelectWithSpace(mock)
 
 		slugCheckMock(mock, Data)
-		sameNameFind(mock, false)
 
 		ratingUpdateMock(mock, updatedRating, nil)
 		mock.ExpectCommit()
@@ -130,7 +127,6 @@ func TestRatingUpdate(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
 		SelectWithSpace(mock)
-		sameNameFind(mock, false)
 
 		mock.ExpectBegin()
 		mock.ExpectExec(`UPDATE \"ratings\" SET (.+)  WHERE (.+) \"ratings\".\"id\" = `).
@@ -169,7 +165,6 @@ func TestRatingUpdate(t *testing.T) {
 			WithArgs(fmt.Sprint(updatedRating["slug"], "%"), 1).
 			WillReturnRows(sqlmock.NewRows([]string{"slug", "space_id"}))
 
-		sameNameFind(mock, false)
 		ratingUpdateMock(mock, updatedRating, nil)
 		mock.ExpectCommit()
 
@@ -193,7 +188,6 @@ func TestRatingUpdate(t *testing.T) {
 			WithArgs(fmt.Sprint(updatedRating["slug"], "%"), 1).
 			WillReturnRows(sqlmock.NewRows([]string{"slug", "space_id"}))
 
-		sameNameFind(mock, false)
 		ratingUpdateMock(mock, updatedRating, errors.New("record not found"))
 		mock.ExpectRollback()
 
@@ -209,11 +203,12 @@ func TestRatingUpdate(t *testing.T) {
 
 	t.Run("rating with same name exist", func(t *testing.T) {
 		updatedRating["slug"] = "true"
+		updatedRating["name"] = "New Rating"
 		test.CheckSpaceMock(mock)
 
 		SelectWithSpace(mock)
 
-		sameNameFind(mock, true)
+		sameNameCount(mock, 1, updatedRating["name"])
 
 		e.PUT(path).
 			WithPath("rating_id", 1).
@@ -222,6 +217,7 @@ func TestRatingUpdate(t *testing.T) {
 			Expect().
 			Status(http.StatusUnprocessableEntity)
 		test.ExpectationsMet(t, mock)
+		updatedRating["name"] = "True"
 	})
 
 	t.Run("update rating when meili is down", func(t *testing.T) {
@@ -231,7 +227,6 @@ func TestRatingUpdate(t *testing.T) {
 
 		SelectWithSpace(mock)
 
-		sameNameFind(mock, false)
 		ratingUpdateMock(mock, updatedRating, nil)
 		mock.ExpectRollback()
 

--- a/util/names.go
+++ b/util/names.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/factly/dega-server/config"
+)
+
+// CheckName checks if the table contains any entry with same name
+func CheckName(space uint, name, table string) bool {
+	var count int
+	newName := strings.ToLower(strings.TrimSpace(name))
+	config.DB.Table(table).Where("deleted_at IS NULL AND (space_id = ? AND name ILIKE ?)", space, newName).Count(&count)
+	return count > 0
+}


### PR DESCRIPTION
### Duplicate names are not allowed while creating or updating tags, formats, categories and ratings.