### PR TITLE
Store super organisation info as a policy in keto.

### DIFF
--- a/config/organisation.go
+++ b/config/organisation.go
@@ -85,7 +85,7 @@ func UserConfigPresent() bool {
 
 // CreateSuperOrganisation creates a super user and organisation in kavach
 func CreateSuperOrganisation() error {
-	if !CheckSuperOrganisation() && UserConfigPresent() {
+	if viper.GetBool("super_organisation") && !CheckSuperOrganisation() && UserConfigPresent() {
 		// create a user in kratos through api
 		resp, err := createKratosUser()
 		if err != nil {

--- a/config/organisation.go
+++ b/config/organisation.go
@@ -53,7 +53,10 @@ func CheckSuperOrganisation() bool {
 		return false
 	}
 	var policy ketoPolicy
-	json.NewDecoder(resp.Body).Decode(&policy)
+	err = json.NewDecoder(resp.Body).Decode(&policy)
+	if err != nil {
+		return false
+	}
 
 	if len(policy.Subjects) == 0 {
 		return false

--- a/config/vars.go
+++ b/config/vars.go
@@ -46,4 +46,8 @@ func SetupVars() {
 		log.Fatal("please provide kratos_public_url config param")
 	}
 
+	if !viper.IsSet("super_organisation") {
+		log.Fatal("please provide super_organisation (bool) config param")
+	}
+
 }

--- a/service/core/action/format/create.go
+++ b/service/core/action/format/create.go
@@ -76,7 +76,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	_ = stmt.Parse(&model.Format{})
 	tableName := stmt.Schema.Table
 
-	if formatSlug == "fact-check" {
+	if formatSlug == "fact-check" && config.UserConfigPresent() {
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{
 			OrganisationID: uint(oID),

--- a/service/core/action/format/create.go
+++ b/service/core/action/format/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/renderx"
 	"github.com/factly/x/validationx"
+	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
@@ -76,7 +77,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	_ = stmt.Parse(&model.Format{})
 	tableName := stmt.Schema.Table
 
-	if formatSlug == "fact-check" && config.UserConfigPresent() {
+	if formatSlug == "fact-check" && viper.GetBool("super_organisation") {
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{
 			OrganisationID: uint(oID),

--- a/service/core/action/medium/create.go
+++ b/service/core/action/medium/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/renderx"
 	"github.com/factly/x/validationx"
+	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
@@ -56,7 +57,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if config.UserConfigPresent() {
+	if viper.GetBool("super_organisation") {
 		// Fetch organisation permissions
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{

--- a/service/core/action/medium/create.go
+++ b/service/core/action/medium/create.go
@@ -79,7 +79,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 			SpaceID: uint(sID),
 		}).Count(&totMedia)
 
-		if totMedia+int64(len(mediumList)) >= permission.Media && permission.Media > 0 {
+		if totMedia+int64(len(mediumList)) > permission.Media && permission.Media > 0 {
 			errorx.Render(w, errorx.Parser(errorx.Message{
 				Code:    http.StatusUnprocessableEntity,
 				Message: "cannot create more media",

--- a/service/core/action/medium/create.go
+++ b/service/core/action/medium/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/renderx"
 	"github.com/factly/x/validationx"
-	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
@@ -57,7 +56,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if viper.IsSet("organisation_id") {
+	if config.UserConfigPresent() {
 		// Fetch organisation permissions
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{

--- a/service/core/action/organisationPermission/details.go
+++ b/service/core/action/organisationPermission/details.go
@@ -1,6 +1,8 @@
 package organisationPermission
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/factly/dega-server/util"
@@ -12,6 +14,11 @@ import (
 	"github.com/factly/x/renderx"
 )
 
+type orgPermissionRes struct {
+	model.OrganisationPermission
+	IsAdmin bool `json:"is_admin,omitempty"`
+}
+
 // details - Get tag by id
 // @Summary Show a tag by id
 // @Description Get tag by ID
@@ -21,7 +28,7 @@ import (
 // @Param X-User header string true "User ID"
 // @Param permission_id path string true "Permission ID"
 // @Param X-Space header string true "Space ID"
-// @Success 200 {object} model.OrganisationPermission
+// @Success 200 {object} orgPermissionRes
 // @Router /core/organisations/permissions/my [get]
 func details(w http.ResponseWriter, r *http.Request) {
 	oID, err := util.GetOrganisation(r.Context())
@@ -31,15 +38,26 @@ func details(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := model.OrganisationPermission{}
+	result := orgPermissionRes{}
 	err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{
 		OrganisationID: uint(oID),
-	}).First(&result).Error
+	}).First(&result.OrganisationPermission).Error
 
 	if err != nil {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.RecordNotFound()))
 		return
+	}
+
+	resp, _ := util.KetoGetRequest("/engines/acp/ory/regex/policies/app:dega:superorg")
+
+	if resp.StatusCode == http.StatusOK {
+		var policy model.KetoPolicy
+		json.NewDecoder(resp.Body).Decode(&policy)
+
+		if len(policy.Subjects) > 0 && policy.Subjects[0] == fmt.Sprint(oID) {
+			result.IsAdmin = true
+		}
 	}
 
 	renderx.JSON(w, http.StatusOK, result)

--- a/service/core/action/organisationPermission/details.go
+++ b/service/core/action/organisationPermission/details.go
@@ -53,9 +53,8 @@ func details(w http.ResponseWriter, r *http.Request) {
 
 	if resp.StatusCode == http.StatusOK {
 		var policy model.KetoPolicy
-		json.NewDecoder(resp.Body).Decode(&policy)
-
-		if len(policy.Subjects) > 0 && policy.Subjects[0] == fmt.Sprint(oID) {
+		err = json.NewDecoder(resp.Body).Decode(&policy)
+		if err == nil && len(policy.Subjects) > 0 && policy.Subjects[0] == fmt.Sprint(oID) {
 			result.IsAdmin = true
 		}
 	}

--- a/service/core/action/organisationPermission/list.go
+++ b/service/core/action/organisationPermission/list.go
@@ -30,11 +30,12 @@ type paging struct {
 // @Produce  json
 // @Param X-User header string true "User ID"
 // @Param X-Space header string true "Space ID"
-// @Param limit query string false "limit per page"
-// @Param page query string false "page number"
+// @Param q query string false "Query"
 // @Success 200 {array} paging
 // @Router /core/organisations/permissions [get]
 func list(w http.ResponseWriter, r *http.Request) {
+	searchQuery := r.URL.Query().Get("q")
+
 	result := paging{}
 	result.Nodes = make([]orgWithPermissions, 0)
 
@@ -47,7 +48,7 @@ func list(w http.ResponseWriter, r *http.Request) {
 		permissionMap[permission.OrganisationID] = permission
 	}
 
-	allOrgMap, err := util.GetAllOrganisationsMap()
+	allOrgMap, err := util.GetAllOrganisationsMap(searchQuery)
 	if err != nil {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.InternalServerError()))

--- a/service/core/action/organisationPermission/list.go
+++ b/service/core/action/organisationPermission/list.go
@@ -3,15 +3,23 @@ package organisationPermission
 import (
 	"net/http"
 
+	"github.com/factly/dega-server/util"
+	"github.com/factly/x/errorx"
+	"github.com/factly/x/loggerx"
+
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
-	"github.com/factly/x/paginationx"
 	"github.com/factly/x/renderx"
 )
 
+type orgWithPermissions struct {
+	model.Organisation
+	Permission *model.OrganisationPermission `json:"permission"`
+}
+
 type paging struct {
-	Nodes []model.OrganisationPermission `json:"nodes"`
-	Total int64                          `json:"total"`
+	Nodes []orgWithPermissions `json:"nodes"`
+	Total int64                `json:"total"`
 }
 
 // list - Get all organisation permissions
@@ -28,11 +36,35 @@ type paging struct {
 // @Router /core/organisations/permissions [get]
 func list(w http.ResponseWriter, r *http.Request) {
 	result := paging{}
-	result.Nodes = make([]model.OrganisationPermission, 0)
+	result.Nodes = make([]orgWithPermissions, 0)
 
-	offset, limit := paginationx.Parse(r.URL.Query())
+	permissionList := make([]model.OrganisationPermission, 0)
 
-	config.DB.Model(&model.OrganisationPermission{}).Count(&result.Total).Offset(offset).Limit(limit).Find(&result.Nodes)
+	config.DB.Model(&model.OrganisationPermission{}).Find(&permissionList)
+
+	permissionMap := make(map[uint]model.OrganisationPermission)
+	for _, permission := range permissionList {
+		permissionMap[permission.OrganisationID] = permission
+	}
+
+	allOrgMap, err := util.GetAllOrganisationsMap()
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+		return
+	}
+
+	for oid, organisation := range allOrgMap {
+		owp := orgWithPermissions{}
+		owp.Organisation = organisation
+		if per, found := permissionMap[oid]; found {
+			owp.Permission = &per
+		}
+
+		result.Nodes = append(result.Nodes, owp)
+	}
+
+	result.Total = int64(len(result.Nodes))
 
 	renderx.JSON(w, http.StatusOK, result)
 }

--- a/service/core/action/organisationPermission/route.go
+++ b/service/core/action/organisationPermission/route.go
@@ -10,7 +10,7 @@ type organisationPermission struct {
 	Spaces         int64 `json:"spaces"`
 	Media          int64 `json:"media"`
 	Posts          int64 `json:"posts"`
-	FactCheck      bool  `json:"fact-check"`
+	FactCheck      bool  `json:"fact_check"`
 }
 
 // Router - Group of medium router

--- a/service/core/action/organisationPermission/update.go
+++ b/service/core/action/organisationPermission/update.go
@@ -86,6 +86,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	}).First(&result).Error
 
 	if err != nil {
+		tx.Rollback()
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.DBError()))
 		return

--- a/service/core/action/post/create.go
+++ b/service/core/action/post/create.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/action/author"
 	"github.com/factly/dega-server/service/core/model"
@@ -92,7 +90,7 @@ func createPost(ctx context.Context, post post, status string) (*postData, error
 		return nil, errorx.InternalServerError()
 	}
 
-	if viper.IsSet("organisation_id") {
+	if config.UserConfigPresent() {
 		// Fetch organisation permissions
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{

--- a/service/core/action/post/create.go
+++ b/service/core/action/post/create.go
@@ -19,6 +19,7 @@ import (
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/renderx"
 	"github.com/factly/x/validationx"
+	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
@@ -90,7 +91,7 @@ func createPost(ctx context.Context, post post, status string) (*postData, error
 		return nil, errorx.InternalServerError()
 	}
 
-	if config.UserConfigPresent() {
+	if viper.GetBool("super_organisation") {
 		// Fetch organisation permissions
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{
@@ -156,8 +157,12 @@ func createPost(ctx context.Context, post post, status string) (*postData, error
 		result.Post.PublishedDate = time.Time{}
 	}
 
-	config.DB.Model(&model.Tag{}).Where(post.TagIDs).Find(&result.Post.Tags)
-	config.DB.Model(&model.Category{}).Where(post.CategoryIDs).Find(&result.Post.Categories)
+	if len(post.TagIDs) > 0 {
+		config.DB.Model(&model.Tag{}).Where(post.TagIDs).Find(&result.Post.Tags)
+	}
+	if len(post.CategoryIDs) > 0 {
+		config.DB.Model(&model.Category{}).Where(post.CategoryIDs).Find(&result.Post.Categories)
+	}
 
 	tx := config.DB.Begin()
 

--- a/service/core/action/space/create.go
+++ b/service/core/action/space/create.go
@@ -69,14 +69,21 @@ func create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if config.UserConfigPresent() {
+	if viper.GetBool("super_organisation") {
+		superOrgID, err := util.GetSuperOrganisationID()
+		if err != nil {
+			loggerx.Error(err)
+			errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+			return
+		}
+
 		// Fetch organisation permissions
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{
 			OrganisationID: uint(space.OrganisationID),
 		}).First(&permission).Error
 
-		if err != nil && space.OrganisationID != viper.GetInt("organisation_id") {
+		if err != nil && space.OrganisationID != superOrgID {
 			loggerx.Error(err)
 			errorx.Render(w, errorx.Parser(errorx.Message{
 				Code:    http.StatusUnprocessableEntity,

--- a/service/core/action/space/create.go
+++ b/service/core/action/space/create.go
@@ -69,7 +69,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if viper.IsSet("organisation_id") {
+	if config.UserConfigPresent() {
 		// Fetch organisation permissions
 		permission := model.OrganisationPermission{}
 		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{

--- a/service/core/model/organisation.go
+++ b/service/core/model/organisation.go
@@ -2,6 +2,16 @@ package model
 
 import "github.com/factly/dega-server/config"
 
+// Organisation model
+type Organisation struct {
+	config.Base
+	Title            string  `json:"title"`
+	Slug             string  `json:"slug"`
+	Description      string  `json:"description"`
+	FeaturedMediumID *uint   `json:"featured_medium_id"`
+	Medium           *Medium `json:"medium"`
+}
+
 // OrganisationPermission model
 type OrganisationPermission struct {
 	config.Base

--- a/service/core/model/organisation.go
+++ b/service/core/model/organisation.go
@@ -9,5 +9,5 @@ type OrganisationPermission struct {
 	Spaces         int64 `gorm:"column:spaces" json:"spaces"`
 	Media          int64 `gorm:"column:mediums" json:"media"`
 	Posts          int64 `gorm:"column:posts" json:"posts"`
-	FactCheck      bool  `gorm:"fact_check" json:"fact-check"`
+	FactCheck      bool  `gorm:"fact_check" json:"fact_check"`
 }

--- a/test/mock.go
+++ b/test/mock.go
@@ -36,6 +36,7 @@ func SetupMockDB() sqlmock.Sqlmock {
 	viper.Set("meili_url", "http://meili:7700")
 	viper.Set("meili_key", "password")
 	viper.Set("imageproxy_url", "http://imageproxy")
+	viper.Set("super_organisation", true)
 	google.GoogleURL = "http://googlefactchecktest.com"
 
 	meili.Client = meilisearch.NewClient(meilisearch.Config{

--- a/test/mockServers.go
+++ b/test/mockServers.go
@@ -32,7 +32,7 @@ func KavachGock() {
 	gock.New(viper.GetString("kavach_url") + "/organisations").
 		Persist().
 		Reply(http.StatusOK).
-		JSON(Dummy_Org)
+		JSON(PaiganatedOrg)
 
 }
 

--- a/test/models.go
+++ b/test/models.go
@@ -10,6 +10,7 @@ var Dummy_Org = map[string]interface{}{
 	"updated_at": time.Now(),
 	"deleted_at": nil,
 	"title":      "test org",
+	"slug":       "test-org",
 	"permission": map[string]interface{}{
 		"id":              1,
 		"created_at":      time.Now(),
@@ -21,6 +22,13 @@ var Dummy_Org = map[string]interface{}{
 		"organisation":    nil,
 		"role":            "owner",
 	},
+}
+
+var PaiganatedOrg = map[string]interface{}{
+	"nodes": []interface{}{
+		Dummy_Org,
+	},
+	"total": 1,
 }
 
 var Dummy_Org_Member_List = []map[string]interface{}{

--- a/test/models.go
+++ b/test/models.go
@@ -152,7 +152,7 @@ var Dummy_SingleMock = map[string]interface{}{
 	"id":          "id:org:1:app:dega:space:1:test-policy-0",
 	"description": "",
 	"subjects": []string{
-		"",
+		"1",
 	},
 	"resources": []string{
 		"resources:org:12:app:dega:space:18:policies",

--- a/test/service/core/medium/create_test.go
+++ b/test/service/core/medium/create_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/factly/dega-server/test/service/core/organisationPermission"
-	"github.com/spf13/viper"
 
 	"github.com/factly/dega-server/service"
 	"github.com/factly/dega-server/test"
@@ -53,8 +52,6 @@ func TestMediumCreate(t *testing.T) {
 			Status(http.StatusUnprocessableEntity)
 
 	})
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("create medium", func(t *testing.T) {
 

--- a/test/service/core/organisationPermission/create_test.go
+++ b/test/service/core/organisationPermission/create_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/factly/dega-server/service"
 	"github.com/factly/dega-server/test"
 	"github.com/gavv/httpexpect"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -27,7 +26,6 @@ func TestOrganisationPermissionCreate(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-	viper.Set("organisation_id", 1)
 
 	t.Run("Unprocessable permission", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
@@ -58,7 +56,7 @@ func TestOrganisationPermissionCreate(t *testing.T) {
 
 		mock.ExpectBegin()
 		mock.ExpectQuery(`INSERT INTO "organisation_permissions"`).
-			WithArgs(test.AnyTime{}, test.AnyTime{}, nil, Data["organisation_id"], Data["spaces"], Data["media"], Data["posts"], Data["fact-check"]).
+			WithArgs(test.AnyTime{}, test.AnyTime{}, nil, Data["organisation_id"], Data["spaces"], Data["media"], Data["posts"], Data["fact_check"]).
 			WillReturnRows(sqlmock.
 				NewRows([]string{"id"}).
 				AddRow(1))

--- a/test/service/core/organisationPermission/delete_test.go
+++ b/test/service/core/organisationPermission/delete_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/factly/dega-server/service"
 	"github.com/factly/dega-server/test"
 	"github.com/gavv/httpexpect"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -26,8 +25,6 @@ func TestOrganisationPermissionDelete(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("invalid permission id", func(t *testing.T) {
 		test.CheckSpaceMock(mock)

--- a/test/service/core/organisationPermission/details_test.go
+++ b/test/service/core/organisationPermission/details_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/factly/dega-server/service"
 	"github.com/factly/dega-server/test"
 	"github.com/gavv/httpexpect"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -24,8 +23,6 @@ func TestOrganisationPermissionDetails(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("permission record not found", func(t *testing.T) {
 		test.CheckSpaceMock(mock)

--- a/test/service/core/organisationPermission/list_test.go
+++ b/test/service/core/organisationPermission/list_test.go
@@ -29,10 +29,6 @@ func TestOrganisationPermissionList(t *testing.T) {
 	t.Run("get empty list of permissions", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		mock.ExpectQuery(countQuery).
-			WillReturnRows(sqlmock.NewRows([]string{"count"}).
-				AddRow(0))
-
 		mock.ExpectQuery(selectQuery).
 			WillReturnRows(sqlmock.NewRows(columns))
 
@@ -44,21 +40,18 @@ func TestOrganisationPermissionList(t *testing.T) {
 			Object().
 			Value("nodes").
 			Array().
-			Empty()
+			Length().
+			Equal(1)
+
 		test.ExpectationsMet(t, mock)
 	})
 
 	t.Run("get list of permissions", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
 
-		mock.ExpectQuery(countQuery).
-			WillReturnRows(sqlmock.NewRows([]string{"count"}).
-				AddRow(len(permissionList)))
-
 		mock.ExpectQuery(selectQuery).
 			WillReturnRows(sqlmock.NewRows(columns).
-				AddRow(1, time.Now(), time.Now(), nil, permissionList[0]["organisation_id"], permissionList[0]["spaces"], permissionList[0]["media"], permissionList[0]["posts"], permissionList[0]["fact_check"]).
-				AddRow(2, time.Now(), time.Now(), nil, permissionList[1]["organisation_id"], permissionList[1]["spaces"], permissionList[1]["media"], permissionList[1]["posts"], permissionList[1]["fact_check"]))
+				AddRow(1, time.Now(), time.Now(), nil, Data["organisation_id"], Data["spaces"], Data["media"], Data["posts"], Data["fact_check"]))
 
 		e.GET(basePath).
 			WithHeaders(headers).
@@ -70,33 +63,10 @@ func TestOrganisationPermissionList(t *testing.T) {
 			Array().
 			Element(0).
 			Object().
-			ContainsMap(permissionList[0])
+			Value("permission").
+			Object().
+			ContainsMap(Data)
 		test.ExpectationsMet(t, mock)
 	})
 
-	t.Run("get list of permissions with pagination", func(t *testing.T) {
-		test.CheckSpaceMock(mock)
-
-		mock.ExpectQuery(countQuery).
-			WillReturnRows(sqlmock.NewRows([]string{"count"}).
-				AddRow(len(permissionList)))
-
-		mock.ExpectQuery(selectQuery).
-			WillReturnRows(sqlmock.NewRows(columns).
-				AddRow(2, time.Now(), time.Now(), nil, permissionList[1]["organisation_id"], permissionList[1]["spaces"], permissionList[1]["media"], permissionList[1]["posts"], permissionList[1]["fact_check"]))
-
-		e.GET(basePath).
-			WithHeaders(headers).
-			WithQueryObject(map[string]interface{}{"page": 2, "limit": 1}).
-			Expect().
-			Status(http.StatusOK).
-			JSON().
-			Object().
-			Value("nodes").
-			Array().
-			Element(0).
-			Object().
-			ContainsMap(permissionList[1])
-		test.ExpectationsMet(t, mock)
-	})
 }

--- a/test/service/core/organisationPermission/list_test.go
+++ b/test/service/core/organisationPermission/list_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/factly/dega-server/service"
 	"github.com/factly/dega-server/test"
 	"github.com/gavv/httpexpect"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -26,8 +25,6 @@ func TestOrganisationPermissionList(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("get empty list of permissions", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
@@ -60,8 +57,8 @@ func TestOrganisationPermissionList(t *testing.T) {
 
 		mock.ExpectQuery(selectQuery).
 			WillReturnRows(sqlmock.NewRows(columns).
-				AddRow(1, time.Now(), time.Now(), nil, permissionList[0]["organisation_id"], permissionList[0]["spaces"], permissionList[0]["media"], permissionList[0]["posts"], permissionList[0]["fact-check"]).
-				AddRow(2, time.Now(), time.Now(), nil, permissionList[1]["organisation_id"], permissionList[1]["spaces"], permissionList[1]["media"], permissionList[1]["posts"], permissionList[1]["fact-check"]))
+				AddRow(1, time.Now(), time.Now(), nil, permissionList[0]["organisation_id"], permissionList[0]["spaces"], permissionList[0]["media"], permissionList[0]["posts"], permissionList[0]["fact_check"]).
+				AddRow(2, time.Now(), time.Now(), nil, permissionList[1]["organisation_id"], permissionList[1]["spaces"], permissionList[1]["media"], permissionList[1]["posts"], permissionList[1]["fact_check"]))
 
 		e.GET(basePath).
 			WithHeaders(headers).
@@ -86,7 +83,7 @@ func TestOrganisationPermissionList(t *testing.T) {
 
 		mock.ExpectQuery(selectQuery).
 			WillReturnRows(sqlmock.NewRows(columns).
-				AddRow(2, time.Now(), time.Now(), nil, permissionList[1]["organisation_id"], permissionList[1]["spaces"], permissionList[1]["media"], permissionList[1]["posts"], permissionList[1]["fact-check"]))
+				AddRow(2, time.Now(), time.Now(), nil, permissionList[1]["organisation_id"], permissionList[1]["spaces"], permissionList[1]["media"], permissionList[1]["posts"], permissionList[1]["fact_check"]))
 
 		e.GET(basePath).
 			WithHeaders(headers).

--- a/test/service/core/organisationPermission/testvars.go
+++ b/test/service/core/organisationPermission/testvars.go
@@ -31,23 +31,6 @@ var undecodableData = map[string]interface{}{
 	"spes":            5,
 }
 
-var permissionList = []map[string]interface{}{
-	{
-		"organisation_id": 1,
-		"spaces":          5,
-		"media":           10,
-		"posts":           10,
-		"fact_check":      true,
-	},
-	{
-		"organisation_id": 2,
-		"spaces":          3,
-		"media":           20,
-		"posts":           20,
-		"fact_check":      true,
-	},
-}
-
 var columns = []string{"id", "created_at", "updated_at", "deleted_at", "organisation_id", "spaces", "media", "posts", "fact_check"}
 
 var selectQuery = regexp.QuoteMeta(`SELECT * FROM "organisation_permissions"`)

--- a/test/service/core/organisationPermission/testvars.go
+++ b/test/service/core/organisationPermission/testvars.go
@@ -18,7 +18,7 @@ var Data = map[string]interface{}{
 	"spaces":          5,
 	"media":           10,
 	"posts":           10,
-	"fact-check":      true,
+	"fact_check":      true,
 }
 
 var invalidData = map[string]interface{}{
@@ -37,14 +37,14 @@ var permissionList = []map[string]interface{}{
 		"spaces":          5,
 		"media":           10,
 		"posts":           10,
-		"fact-check":      true,
+		"fact_check":      true,
 	},
 	{
 		"organisation_id": 2,
 		"spaces":          3,
 		"media":           20,
 		"posts":           20,
-		"fact-check":      true,
+		"fact_check":      true,
 	},
 }
 
@@ -62,5 +62,5 @@ func SelectQuery(mock sqlmock.Sqlmock, args ...driver.Value) {
 	mock.ExpectQuery(selectQuery).
 		WithArgs(args...).
 		WillReturnRows(sqlmock.NewRows(columns).
-			AddRow(1, time.Now(), time.Now(), nil, Data["organisation_id"], Data["spaces"], Data["media"], Data["posts"], Data["fact-check"]))
+			AddRow(1, time.Now(), time.Now(), nil, Data["organisation_id"], Data["spaces"], Data["media"], Data["posts"], Data["fact_check"]))
 }

--- a/test/service/core/organisationPermission/update_test.go
+++ b/test/service/core/organisationPermission/update_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/factly/dega-server/service"
 	"github.com/factly/dega-server/test"
 	"github.com/gavv/httpexpect"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -26,8 +25,6 @@ func TestOrganisationPermissionUpdate(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("invalid permission id", func(t *testing.T) {
 		test.CheckSpaceMock(mock)
@@ -80,7 +77,7 @@ func TestOrganisationPermissionUpdate(t *testing.T) {
 
 		mock.ExpectBegin()
 		mock.ExpectExec(`UPDATE \"organisation_permissions\"`).
-			WithArgs(Data["fact-check"], 1).
+			WithArgs(Data["fact_check"], 1).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`UPDATE \"organisation_permissions\"`).
 			WithArgs(test.AnyTime{}, Data["spaces"], Data["media"], Data["posts"], 1).

--- a/test/service/core/post/create_test.go
+++ b/test/service/core/post/create_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/factly/dega-server/test/service/core/medium"
 	"github.com/factly/dega-server/test/service/core/tag"
 	"github.com/gavv/httpexpect/v2"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -35,8 +34,6 @@ func TestPostCreate(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("Unprocessable post", func(t *testing.T) {
 

--- a/test/service/core/post/publish_create_test.go
+++ b/test/service/core/post/publish_create_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/factly/dega-server/test/service/core/organisationPermission"
 	"github.com/factly/dega-server/test/service/core/tag"
 	"github.com/gavv/httpexpect/v2"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -32,8 +31,6 @@ func TestPublishedPostCreate(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("Unprocessable post", func(t *testing.T) {
 

--- a/test/service/core/space/create_test.go
+++ b/test/service/core/space/create_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/factly/dega-server/test"
 	"github.com/factly/dega-server/test/service/core/organisationPermission"
 	"github.com/gavv/httpexpect"
-	"github.com/spf13/viper"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -29,8 +28,6 @@ func TestSpaceCreate(t *testing.T) {
 
 	// create httpexpect instance
 	e := httpexpect.New(t, testServer.URL)
-
-	viper.Set("organisation_id", 1)
 
 	t.Run("create a space", func(t *testing.T) {
 		insertMock(mock)
@@ -68,10 +65,10 @@ func TestSpaceCreate(t *testing.T) {
 	})
 
 	t.Run("create space when no permission found", func(t *testing.T) {
-		viper.Set("organisation_id", 2)
+		Data["organisation_id"] = 2
 
 		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "organisation_permissions"`)).
-			WithArgs(1).
+			WithArgs(2).
 			WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "deleted_at", "organisation_id", "spaces", "mediums", "posts"}))
 
 		e.POST(basePath).
@@ -79,12 +76,11 @@ func TestSpaceCreate(t *testing.T) {
 			WithJSON(Data).
 			Expect().
 			Status(http.StatusUnprocessableEntity)
-
+		Data["organisation_id"] = 1
 		test.ExpectationsMet(t, mock)
 	})
 
 	t.Run("create more than allowed spaces", func(t *testing.T) {
-		viper.Set("organisation_id", 2)
 
 		organisationPermission.SelectQuery(mock, 1)
 

--- a/util/organisation.go
+++ b/util/organisation.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/factly/dega-server/service/core/model"
@@ -15,8 +16,14 @@ type paging struct {
 }
 
 // GetAllOrganisationsMap return slice of all organisations
-func GetAllOrganisationsMap() (map[uint]model.Organisation, error) {
-	req, err := http.NewRequest("GET", viper.GetString("kavach_url")+"/organisations", nil)
+func GetAllOrganisationsMap(q string) (map[uint]model.Organisation, error) {
+
+	path := "/organisations"
+	if q != "" {
+		path = fmt.Sprint(path, "?q=", q)
+	}
+
+	req, err := http.NewRequest("GET", viper.GetString("kavach_url")+path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/util/organisation.go
+++ b/util/organisation.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/factly/dega-server/service/core/model"
+	"github.com/spf13/viper"
+)
+
+type paging struct {
+	Nodes []model.Organisation `json:"nodes"`
+	Total int64                `json:"total"`
+}
+
+// GetAllOrganisationsMap return slice of all organisations
+func GetAllOrganisationsMap() (map[uint]model.Organisation, error) {
+	req, err := http.NewRequest("GET", viper.GetString("kavach_url")+"/organisations", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var pagingList paging
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("could not fetch organisations")
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&pagingList)
+	if err != nil {
+		return nil, err
+	}
+
+	orgMap := make(map[uint]model.Organisation)
+
+	for _, organisation := range pagingList.Nodes {
+		orgMap[organisation.ID] = organisation
+	}
+	return orgMap, nil
+}

--- a/util/super_organisation.go
+++ b/util/super_organisation.go
@@ -2,42 +2,36 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/factly/dega-server/config"
 	"github.com/factly/dega-server/service/core/model"
+	"github.com/spf13/viper"
 )
 
 // CheckSuperOrganisation checks weather organisation of user is super org or not
 func CheckSuperOrganisation(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !viper.GetBool("super_organisation") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
 		oID, err := GetOrganisation(r.Context())
 		if err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 
-		resp, err := KetoGetRequest("/engines/acp/ory/regex/policies/app:dega:superorg")
+		superOrgID, err := GetSuperOrganisationID()
 		if err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-
-		var policy model.KetoPolicy
-		json.NewDecoder(resp.Body).Decode(&policy)
-
-		if len(policy.Subjects) == 0 {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-
-		if fmt.Sprint(oID) != policy.Subjects[0] {
+		if oID != superOrgID {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -46,28 +40,49 @@ func CheckSuperOrganisation(h http.Handler) http.Handler {
 	})
 }
 
+// GetSuperOrganisationID get superorganisation id from keto policy
+func GetSuperOrganisationID() (int, error) {
+	resp, err := KetoGetRequest("/engines/acp/ory/regex/policies/app:dega:superorg")
+	if err != nil {
+		return 0, err
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		var policy model.KetoPolicy
+		json.NewDecoder(resp.Body).Decode(&policy)
+
+		if len(policy.Subjects) != 0 {
+			orgID, _ := strconv.Atoi(policy.Subjects[0])
+			return orgID, nil
+		}
+	}
+	return 0, errors.New("cannot get super organisation id")
+}
+
 // FactCheckPermission checks weather organisation has fact-check permission
 func FactCheckPermission(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		oID, err := GetOrganisation(r.Context())
-		if err != nil {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
+		if viper.GetBool("super_organisation") {
+			oID, err := GetOrganisation(r.Context())
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 
-		permission := model.OrganisationPermission{}
-		err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{
-			OrganisationID: uint(oID),
-		}).First(&permission).Error
+			permission := model.OrganisationPermission{}
+			err = config.DB.Model(&model.OrganisationPermission{}).Where(&model.OrganisationPermission{
+				OrganisationID: uint(oID),
+			}).First(&permission).Error
 
-		if err != nil {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 
-		if !permission.FactCheck {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
+			if !permission.FactCheck {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 		}
 
 		h.ServeHTTP(w, r)

--- a/util/super_organisation.go
+++ b/util/super_organisation.go
@@ -49,7 +49,10 @@ func GetSuperOrganisationID() (int, error) {
 
 	if resp.StatusCode == http.StatusOK {
 		var policy model.KetoPolicy
-		json.NewDecoder(resp.Body).Decode(&policy)
+		err = json.NewDecoder(resp.Body).Decode(&policy)
+		if err != nil {
+			return 0, err
+		}
 
 		if len(policy.Subjects) != 0 {
 			orgID, _ := strconv.Atoi(policy.Subjects[0])


### PR DESCRIPTION
* After the creation of super_organisation following keto policy is upserted
```json
{
    "id": "app:dega:superorg",
    "description": "",
    "subjects": [
        "<org_id>"
    ],
    "resources": [
        "resources:org:<org_id>:<.*>"
    ],
    "actions": [
        "actions:org:<org_id>:<.*>"
    ],
    "effect": "allow",
    "conditions": null
}
```
* `/core/organisations/permissions/my` returns object containing `"is_admin" = true` if the requesting user is part of super organisation.
* All the super organisation features can be **enabled/disabled** based on `SUPER_ORGANISATION` bool config parameter.
* `/organisations/permissions` route returns organisations info along with permissions (can pass q param to filter orgs) (eg below):
```json
        {
            "id": 2,
            "created_at": "2020-11-01T11:39:37.828656Z",
            "updated_at": "2020-11-01T11:39:37.828656Z",
            "deleted_at": null,
            "title": "Factly.in",
            "slug": "",
            "description": "",
            "featured_medium_id": null,
            "medium": null,
            "permission": {
                "id": 2,
                "created_at": "2020-11-06T09:55:18.876023Z",
                "updated_at": "2020-11-13T05:38:37.736517Z",
                "deleted_at": null,
                "organisation_id": 2,
                "spaces": 2,
                "media": 0,
                "posts": 2,
                "fact_check": true
            }
        }
```