### PR TITLE
Changes related to accessibility and functionalities of webhooks and events.

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,116 @@
+[
+    {
+        "name": "category.created"
+    },
+    {
+        "name": "category.updated"
+    },
+    {
+        "name": "category.deleted"
+    },
+    {
+        "name": "format.created"
+    },
+    {
+        "name": "format.updated"
+    },
+    {
+        "name": "format.deleted"
+    },
+    {
+        "name": "media.created"
+    },
+    {
+        "name": "media.updated"
+    },
+    {
+        "name": "media.deleted"
+    },
+    {
+        "name": "menu.created"
+    },
+    {
+        "name": "menu.updated"
+    },
+    {
+        "name": "menu.deleted"
+    },
+    {
+        "name": "post.created"
+    },
+    {
+        "name": "post.updated"
+    },
+    {
+        "name": "post.deleted"
+    },
+    {
+        "name": "post.template.created"
+    },
+    {
+        "name": "post.published"
+    },
+    {
+        "name": "space.created"
+    },
+    {
+        "name": "space.updated"
+    },
+    {
+        "name": "space.deleted"
+    },
+    {
+        "name": "tag.created"
+    },
+    {
+        "name": "tag.updated"
+    },
+    {
+        "name": "tag.deleted"
+    },
+    {
+        "name": "claim.created"
+    },
+    {
+        "name": "claim.updated"
+    },
+    {
+        "name": "claim.deleted"
+    },
+    {
+        "name": "claimant.created"
+    },
+    {
+        "name": "claimant.updated"
+    },
+    {
+        "name": "claimant.deleted"
+    },
+    {
+        "name": "rating.created"
+    },
+    {
+        "name": "rating.updated"
+    },
+    {
+        "name": "rating.deleted"
+    },
+    {
+        "name": "podcast.created"
+    },
+    {
+        "name": "podcast.updated"
+    },
+    {
+        "name": "podcast.deleted"
+    },
+    {
+        "name": "episode.created"
+    },
+    {
+        "name": "episode.updated"
+    },
+    {
+        "name": "episode.deleted"
+    }
+]

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -436,6 +436,52 @@ var doc = `{
                 }
             }
         },
+        "/core/events/default": {
+            "post": {
+                "description": "Create default Events",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Create default Events",
+                "operationId": "add-default-events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "X-User",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Space ID",
+                        "name": "X-Space",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Event"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/core/events/{event_id}": {
             "get": {
                 "description": "Get event by ID",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -421,6 +421,52 @@
                 }
             }
         },
+        "/core/events/default": {
+            "post": {
+                "description": "Create default Events",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Create default Events",
+                "operationId": "add-default-events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "X-User",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Space ID",
+                        "name": "X-Space",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Event"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/core/events/{event_id}": {
             "get": {
                 "description": "Get event by ID",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2022,6 +2022,37 @@ paths:
       summary: Update a event by id
       tags:
       - Events
+  /core/events/default:
+    post:
+      description: Create default Events
+      operationId: add-default-events
+      parameters:
+      - description: User ID
+        in: header
+        name: X-User
+        required: true
+        type: string
+      - description: Space ID
+        in: header
+        name: X-Space
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.Event'
+        "400":
+          description: Bad Request
+          schema:
+            items:
+              type: string
+            type: array
+      summary: Create default Events
+      tags:
+      - Events
   /core/formats:
     get:
       description: Get all formats

--- a/service/core/action/event/create.go
+++ b/service/core/action/event/create.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/factly/dega-server/service/core/model"
+	"github.com/factly/dega-server/test"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/middlewarex"
@@ -37,6 +39,13 @@ func create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sID, err := middlewarex.GetSpace(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
 	event := &event{}
 
 	if err = json.NewDecoder(r.Body).Decode(&event); err != nil {
@@ -48,6 +57,26 @@ func create(w http.ResponseWriter, r *http.Request) {
 	if validationError := validationx.Check(event); validationError != nil {
 		loggerx.Error(errors.New("validation error"))
 		errorx.Render(w, validationError)
+		return
+	}
+
+	// append app and space tag even if not provided
+	tags := make(map[string]string)
+	if len(event.Tags.RawMessage) > 0 && !reflect.DeepEqual(event.Tags, test.NilJsonb()) {
+		err = json.Unmarshal(event.Tags.RawMessage, &tags)
+		if err != nil {
+			loggerx.Error(err)
+			errorx.Render(w, errorx.Parser(errorx.DecodeError()))
+			return
+		}
+	}
+
+	tags["app"] = "dega"
+	tags["space"] = fmt.Sprint(sID)
+
+	if event.Tags.RawMessage, err = json.Marshal(tags); err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
 		return
 	}
 

--- a/service/core/action/event/default.go
+++ b/service/core/action/event/default.go
@@ -1,0 +1,106 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/factly/dega-server/service/core/model"
+	"github.com/factly/x/errorx"
+	"github.com/factly/x/loggerx"
+	"github.com/factly/x/middlewarex"
+	"github.com/factly/x/renderx"
+	"github.com/factly/x/requestx"
+	"github.com/spf13/viper"
+)
+
+// DataFile default json data file
+var DataFile = "./data/events.json"
+
+// create - Create default Events
+// @Summary Create default Events
+// @Description Create default Events
+// @Tags Events
+// @ID add-default-events
+// @Consume json
+// @Produce json
+// @Param X-User header string true "User ID"
+// @Param X-Space header string true "Space ID"
+// @Success 201 {object} model.Event
+// @Failure 400 {array} string
+// @Router /core/events/default [post]
+func defaults(w http.ResponseWriter, r *http.Request) {
+	sID, err := middlewarex.GetSpace(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
+	uID, err := middlewarex.GetUser(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
+	jsonFile, err := os.Open(DataFile)
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+		return
+	}
+
+	defer jsonFile.Close()
+
+	events := make([]event, 0)
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	err = json.Unmarshal(byteValue, &events)
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+		return
+	}
+
+	eventsResp := make([]model.Event, 0)
+	for i := range events {
+		if err = AddTags(&events[i], sID); err != nil {
+			loggerx.Error(err)
+			errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+			return
+		}
+
+		hukzURL := viper.GetString("hukz_url") + "/events"
+
+		resp, err := requestx.Request("POST", hukzURL, events[i], map[string]string{
+			"X-User": fmt.Sprint(uID),
+		})
+
+		if err != nil {
+			loggerx.Error(err)
+			errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+			return
+		}
+
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			continue
+		}
+
+		if resp.StatusCode != http.StatusCreated {
+			errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+			return
+		}
+
+		var eventRes model.Event
+		if err = json.NewDecoder(resp.Body).Decode(&eventRes); err != nil {
+			errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+			return
+		}
+		eventsResp = append(eventsResp, eventRes)
+
+	}
+	renderx.JSON(w, http.StatusCreated, eventsResp)
+}

--- a/service/core/action/event/delete.go
+++ b/service/core/action/event/delete.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -56,6 +57,13 @@ func delete(w http.ResponseWriter, r *http.Request) {
 
 	if resp.StatusCode == http.StatusNotFound {
 		errorx.Render(w, errorx.Parser(errorx.RecordNotFound()))
+		return
+	}
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		body := map[string]interface{}{}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		renderx.JSON(w, http.StatusUnprocessableEntity, body)
 		return
 	}
 

--- a/service/core/action/event/list.go
+++ b/service/core/action/event/list.go
@@ -39,7 +39,14 @@ func list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hukzURL := viper.GetString("hukz_url") + "/events?tag=app:dega&limit=" + r.URL.Query().Get("limit") + "&page=" + r.URL.Query().Get("page")
+	sID, err := middlewarex.GetSpace(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
+	hukzURL := viper.GetString("hukz_url") + "/events?tag=app:dega&limit=" + r.URL.Query().Get("limit") + "&page=" + r.URL.Query().Get("page") + "&tag=space:" + fmt.Sprint(sID)
 
 	resp, err := requestx.Request("GET", hukzURL, nil, map[string]string{
 		"X-User": fmt.Sprint(uID),

--- a/service/core/action/event/route.go
+++ b/service/core/action/event/route.go
@@ -20,6 +20,7 @@ func Router() chi.Router {
 
 	r.Get("/", list)
 	r.With(middlewarex.CheckSuperOrganisation(app, util.GetOrganisation)).Post("/", create)
+	r.With(middlewarex.CheckSuperOrganisation(app, util.GetOrganisation)).Post("/default", defaults)
 
 	r.Route("/{event_id}", func(r chi.Router) {
 		r.Get("/", details)

--- a/service/core/action/event/route.go
+++ b/service/core/action/event/route.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"github.com/factly/dega-server/util"
+	"github.com/factly/x/middlewarex"
 	"github.com/go-chi/chi"
 	"github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -14,13 +16,15 @@ type event struct {
 func Router() chi.Router {
 	r := chi.NewRouter()
 
+	app := "dega"
+
 	r.Get("/", list)
-	r.Post("/", create)
+	r.With(middlewarex.CheckSuperOrganisation(app, util.GetOrganisation)).Post("/", create)
 
 	r.Route("/{event_id}", func(r chi.Router) {
 		r.Get("/", details)
-		r.Put("/", update)
-		r.Delete("/", delete)
+		r.With(middlewarex.CheckSuperOrganisation(app, util.GetOrganisation)).Put("/", update)
+		r.With(middlewarex.CheckSuperOrganisation(app, util.GetOrganisation)).Delete("/", delete)
 	})
 
 	return r

--- a/service/core/action/event/update.go
+++ b/service/core/action/event/update.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strconv"
 
 	"github.com/factly/dega-server/service/core/model"
-	"github.com/factly/dega-server/test"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/middlewarex"
@@ -72,22 +70,9 @@ func update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// append app and space tag even if not provided
-	tags := make(map[string]string)
-	if len(event.Tags.RawMessage) > 0 && !reflect.DeepEqual(event.Tags, test.NilJsonb()) {
-		err = json.Unmarshal(event.Tags.RawMessage, &tags)
-		if err != nil {
-			loggerx.Error(err)
-			errorx.Render(w, errorx.Parser(errorx.DecodeError()))
-			return
-		}
-	}
-
-	tags["app"] = "dega"
-	tags["space"] = fmt.Sprint(sID)
-
-	if event.Tags.RawMessage, err = json.Marshal(tags); err != nil {
+	if err = AddTags(event, sID); err != nil {
 		loggerx.Error(err)
-		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
+		errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
 		return
 	}
 

--- a/service/core/action/format/default.go
+++ b/service/core/action/format/default.go
@@ -67,9 +67,7 @@ func createDefaults(w http.ResponseWriter, r *http.Request) {
 	tx := config.DB.WithContext(context.WithValue(r.Context(), userContext, uID)).Begin()
 	for i := range formats {
 		formats[i].SpaceID = uint(sID)
-	}
-	tx.Model(&model.Format{}).Create(&formats)
-	for i := range formats {
+		tx.Model(&model.Format{}).FirstOrCreate(&formats[i], &formats[i])
 		err = insertIntoMeili(formats[i])
 		if err != nil {
 			tx.Rollback()

--- a/service/core/action/policy/composer.go
+++ b/service/core/action/policy/composer.go
@@ -23,7 +23,7 @@ func contains(s []string, e string) bool {
 
 // Composer create keto policy
 func Composer(oID int, sID int, inputPolicy policyReq) model.KetoPolicy {
-	allowedResources := []string{"categories", "formats", "media", "policies", "posts", "tags", "claims", "claimants", "fact-checks", "ratings", "google", "menus", "episodes", "podcasts"}
+	allowedResources := []string{"categories", "formats", "media", "policies", "posts", "tags", "webhooks", "claims", "claimants", "fact-checks", "ratings", "google", "menus", "episodes", "podcasts"}
 	allowedActions := []string{"get", "create", "update", "delete", "publish"}
 	result := model.KetoPolicy{}
 

--- a/service/core/action/post/create.go
+++ b/service/core/action/post/create.go
@@ -314,6 +314,12 @@ func createPost(ctx context.Context, post post, status string) (*postData, error
 		if err = util.NC.Publish("post.created", result); err != nil {
 			return nil, errorx.GetMessage("not able to publish event", http.StatusInternalServerError)
 		}
+
+		if result.Post.Status == "publish" {
+			if err = util.NC.Publish("post.published", result); err != nil {
+				return nil, errorx.GetMessage("not able to publish event", http.StatusInternalServerError)
+			}
+		}
 	}
 
 	return result, errorx.Message{}

--- a/service/core/action/post/update.go
+++ b/service/core/action/post/update.go
@@ -436,6 +436,13 @@ func update(w http.ResponseWriter, r *http.Request) {
 			errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
 			return
 		}
+		if result.Post.Status == "publish" {
+			if err = util.NC.Publish("post.published", result); err != nil {
+				loggerx.Error(err)
+				errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
+				return
+			}
+		}
 	}
 
 	renderx.JSON(w, http.StatusOK, result)

--- a/service/core/action/webhook/create.go
+++ b/service/core/action/webhook/create.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 
 	"github.com/factly/dega-server/service/core/model"
+	"github.com/factly/dega-server/test"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/middlewarex"
@@ -37,6 +39,13 @@ func create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sID, err := middlewarex.GetSpace(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
 	webhook := &webhook{}
 
 	if err = json.NewDecoder(r.Body).Decode(&webhook); err != nil {
@@ -48,6 +57,26 @@ func create(w http.ResponseWriter, r *http.Request) {
 	if validationError := validationx.Check(webhook); validationError != nil {
 		loggerx.Error(errors.New("validation error"))
 		errorx.Render(w, validationError)
+		return
+	}
+
+	// append app and space tag even if not provided
+	tags := make(map[string]string)
+	if len(webhook.Tags.RawMessage) > 0 && !reflect.DeepEqual(webhook.Tags, test.NilJsonb()) {
+		err = json.Unmarshal(webhook.Tags.RawMessage, &tags)
+		if err != nil {
+			loggerx.Error(err)
+			errorx.Render(w, errorx.Parser(errorx.DecodeError()))
+			return
+		}
+	}
+
+	tags["app"] = "dega"
+	tags["space"] = fmt.Sprint(sID)
+
+	if webhook.Tags.RawMessage, err = json.Marshal(tags); err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
 		return
 	}
 

--- a/service/core/action/webhook/list.go
+++ b/service/core/action/webhook/list.go
@@ -40,7 +40,14 @@ func list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hukzURL := viper.GetString("hukz_url") + "/webhooks?tag=app:dega&limit=" + r.URL.Query().Get("limit") + "&page=" + r.URL.Query().Get("page")
+	sID, err := middlewarex.GetSpace(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
+	hukzURL := viper.GetString("hukz_url") + "/webhooks?tag=app:dega&tag=space:" + fmt.Sprint(sID) + "&limit=" + r.URL.Query().Get("limit") + "&page=" + r.URL.Query().Get("page")
 
 	resp, err := requestx.Request("GET", hukzURL, nil, map[string]string{
 		"X-User": fmt.Sprint(uID),

--- a/service/core/action/webhook/logs.go
+++ b/service/core/action/webhook/logs.go
@@ -39,7 +39,14 @@ func logs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hukzURL := viper.GetString("hukz_url") + "/webhooks/logs?tag=app:dega&limit=" + r.URL.Query().Get("limit") + "&page=" + r.URL.Query().Get("page")
+	sID, err := middlewarex.GetSpace(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
+	hukzURL := viper.GetString("hukz_url") + "/webhooks/logs?tag=app:dega&tag=space:" + fmt.Sprint(sID) + "&limit=" + r.URL.Query().Get("limit") + "&page=" + r.URL.Query().Get("page")
 
 	resp, err := requestx.Request("GET", hukzURL, nil, map[string]string{
 		"X-User": fmt.Sprint(uID),

--- a/service/core/action/webhook/route.go
+++ b/service/core/action/webhook/route.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"github.com/factly/dega-server/util"
 	"github.com/go-chi/chi"
 	"github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -16,13 +17,15 @@ type webhook struct {
 func Router() chi.Router {
 	r := chi.NewRouter()
 
-	r.Get("/", list)
-	r.Post("/", create)
-	r.Get("/logs", logs)
+	entity := "webhooks"
+
+	r.With(util.CheckKetoPolicy(entity, "get")).Get("/", list)
+	r.With(util.CheckKetoPolicy(entity, "create")).Post("/", create)
+	r.With(util.CheckKetoPolicy(entity, "get")).Get("/logs", logs)
 	r.Route("/{webhook_id}", func(r chi.Router) {
-		r.Get("/", details)
-		r.Put("/", update)
-		r.Delete("/", delete)
+		r.With(util.CheckKetoPolicy(entity, "get")).Get("/", details)
+		r.With(util.CheckKetoPolicy(entity, "update")).Put("/", update)
+		r.With(util.CheckKetoPolicy(entity, "deletgete")).Delete("/", delete)
 	})
 
 	return r

--- a/service/core/action/webhook/update.go
+++ b/service/core/action/webhook/update.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strconv"
 
 	"github.com/factly/dega-server/service/core/model"
-	"github.com/factly/dega-server/test"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/middlewarex"
@@ -72,22 +70,9 @@ func update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// append app and space tag even if not provided
-	tags := make(map[string]string)
-	if len(webhook.Tags.RawMessage) > 0 && !reflect.DeepEqual(webhook.Tags, test.NilJsonb()) {
-		err = json.Unmarshal(webhook.Tags.RawMessage, &tags)
-		if err != nil {
-			loggerx.Error(err)
-			errorx.Render(w, errorx.Parser(errorx.DecodeError()))
-			return
-		}
-	}
-
-	tags["app"] = "dega"
-	tags["space"] = fmt.Sprint(sID)
-
-	if webhook.Tags.RawMessage, err = json.Marshal(tags); err != nil {
+	if err = AddTags(webhook, sID); err != nil {
 		loggerx.Error(err)
-		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
+		errorx.Render(w, errorx.Parser(errorx.InternalServerError()))
 		return
 	}
 

--- a/service/core/action/webhook/update.go
+++ b/service/core/action/webhook/update.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strconv"
 
 	"github.com/factly/dega-server/service/core/model"
+	"github.com/factly/dega-server/test"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/middlewarex"
@@ -48,6 +50,13 @@ func update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sID, err := middlewarex.GetSpace(r.Context())
+	if err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
+		return
+	}
+
 	webhook := &webhook{}
 
 	if err = json.NewDecoder(r.Body).Decode(&webhook); err != nil {
@@ -59,6 +68,26 @@ func update(w http.ResponseWriter, r *http.Request) {
 	if validationError := validationx.Check(webhook); validationError != nil {
 		loggerx.Error(errors.New("validation error"))
 		errorx.Render(w, validationError)
+		return
+	}
+
+	// append app and space tag even if not provided
+	tags := make(map[string]string)
+	if len(webhook.Tags.RawMessage) > 0 && !reflect.DeepEqual(webhook.Tags, test.NilJsonb()) {
+		err = json.Unmarshal(webhook.Tags.RawMessage, &tags)
+		if err != nil {
+			loggerx.Error(err)
+			errorx.Render(w, errorx.Parser(errorx.DecodeError()))
+			return
+		}
+	}
+
+	tags["app"] = "dega"
+	tags["space"] = fmt.Sprint(sID)
+
+	if webhook.Tags.RawMessage, err = json.Marshal(tags); err != nil {
+		loggerx.Error(err)
+		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
 		return
 	}
 


### PR DESCRIPTION
- Add tags `app:dega` & `space:<id>` by default while creating and updating webhooks & events.
- Filter by webhooks, logs & events by space and app tags by default.
- Events create, update & delete only accessibly by super org.
- Added Keto policy check middleware in webhooks endpoints.
- Added create default events endpoint. (closes #250)
- Implementd FirstOrCreate in creating default ratings & formats. (closes #248)